### PR TITLE
PNDA-3345: Provide the app_packages HDFS location (from Pillar) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3330: Change to use a default application user instead of the hdfs user.
 - PNDA-2445: Support for Hortonworks HDP
 - PNDA-439: Application create API requires a user to run the application as.
+- PNDA-3345: Provide the app_packages HDFS location (from Pillar) to applications deployed with DM
 
 ### Changed
 - PNDA-3486: Place files in HDFS for components under `/user/deployment-manager/applications/<user>/<application>/<component>` to avoid potential clashes using the existing path of `/user/<application>`.

--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ hdfspath_path_name      generated from entries in hdfs.json
 ## Environment Variables ##
 These can be obtained with the [environment endpoints API](#environment-endpoints-api)
 ````
+environment_app_packages_hdfs_path    /user/deployment/app_packages
 environment_hadoop_manager_host       192.168.1.2
 environment_hadoop_manager_password   admin
 environment_hadoop_manager_username   admin


### PR DESCRIPTION
# **User Story:**
PNDA-3345: Provide the app_packages HDFS location (from Pillar) to applications deployed with DM 
Make packages deployed via app-packages available to applications via injecting parameter

An application can use app_packges location defined in pillar " pillar['pnda']['app_packages']['app_packages_hdfs_path']"  to load libraries that are deployed in this location otherwise, the user needs to hard-code paths or use some other out-of-band mechanism to know where things are.

# **Changes:**
Added new Environment variable for application packages location 

 **_environment_app_packages_hdfs_path : /user/deployment/app_packages_**