### PR TITLE
PNDA-2834: Actual application status by deployment manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added:
+- PNDA-2834: Actual application status by deployment manager
 ### Changed
 - PNDA-3555: Place files in HDFS for packages and applications under `/pnda/system/deployment-manager/<packages|applications>`.
 - PNDA-3601: disable emailtext in Jenkins file and replace it with notifier stage and job

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ To build the Deployment Manager, change to the `api` directory, which contains t
   * [GET /applications](#list-all-applications)
   * [GET /packages/_package_/applications](#list-applications-that-have-been-created-from-package)
   * [GET /applications/_application_/status](#get-the-status-for-application)
+  * [GET /applications/_application_/summary](#get-the-summary-status-for-application)
   * [POST /applications/_application_/start](#start-application)
   * [POST /applications/_application_/stop](#stop-application)
   * [GET /applications/_application_](#get-full-information-for-application)
@@ -268,6 +269,91 @@ Response Codes:
 		"name": "spark-batch-example-app-instance"
 }
 
+````
+
+### Get the summary status for _application_
+````
+GET /applications/<application>/summary
+
+Response Codes:
+200 - OK
+404 - Application not known
+500 - Server Error
+````
+
+### Summary status in case of oozie component
+
+````
+{
+  "oozie-application": {
+    "aggregate_status": "STARTED_RUNNING_WITH_ERRORS",
+    "oozie-1": {
+      "status": "WARN",
+      "aggregate_status": "STARTED_RUNNING_WITH_ERRORS",
+      "actions": {
+        "workflow-1": {
+          "status": "WARN",
+          "oozieId": "0000004-171229054340125-oozie-oozi-W",
+          "actions": {
+            "subworkflow-1": {
+              "status": "WARN",
+              "oozieId": "0000005-171229054340125-oozie-oozi-W",
+              "actions": {
+                "job-2": {
+                  "status": "ERROR",
+                  "information": "No JSON object could be decoded",
+                  "applicationType": "SPARK",
+                  "name": "process",
+                  "yarnId": "application_1514526198433_0022"
+                },
+                "job-1": {
+                  "status": "OK",
+                  "information": null,
+                  "applicationType": "MAPREDUCE",
+                  "name": "download",
+                  "yarnId": "application_1514526198433_0019"
+                }
+              },
+              "name": "oozie-application-subworkflow"
+            }
+          },
+          "name": "oozie-application-workflow"
+        }
+      },
+      "oozieId": "0000003-171229054340125-oozie-oozi-C",
+      "name": "oozie-application-coordinator"
+    }
+  }
+}
+````
+### Summary status in case of spark-streaming component
+````
+{
+  "spark-streaming-application": {
+    "aggregate_status": "STARTED_RUNNING_WITH_NO_ERRORS",
+    "sparkStreaming-1": {
+      "information": {
+        "stageSummary": {
+          "active": 0,
+          "number_of_stages": 128,
+          "complete": 128,
+          "pending": 0,
+          "failed": 0
+        },
+        "jobSummary": {
+          "unknown": 0,
+          "number_of_jobs": 32,
+          "running": 0,
+          "succeeded": 32,
+          "failed": 0
+        }
+      },
+      "aggregate_status": "STARTED_RUNNING_WITH_NO_ERRORS",
+      "name": "spark-streaming-application-example-job",
+      "yarnId": "application_1514526198433_0069"
+    }
+  }
+}
 ````
 
 ### Start _application_

--- a/api/src/main/resources/app.py
+++ b/api/src/main/resources/app.py
@@ -34,6 +34,7 @@ from tornado.options import define, options
 import package_registrar
 import application_registrar
 import deployer_utils
+import application_summary_registrar
 import deployment_manager
 from deployer_system_test import DeployerRestClientTester
 from exceptiondef import NotFound, ConflictingState, FailedValidation, FailedCreation
@@ -239,11 +240,12 @@ class ApplicationDetailHandler(BaseHandler):
                 self.send_result(ret)
             elif action == 'detail':
                 self.send_result(dm.get_application_detail(name))
+            elif action == 'summary':
+                self.send_result(dm.get_application_summary(name))
             else:
-                self.send_client_error("%s is not a valid query (status|detail)" % action)
+                self.send_client_error("%s is not a valid query (status|detail|summary)" % action)
 
         DISPATCHER.run_as_asynch(task=do_call, on_error=self.handle_error)
-
 
 class ApplicationHandler(BaseHandler):
     @asynchronous
@@ -310,6 +312,8 @@ def main():
                                                   config['environment']['webhdfs_port'],
                                                   config['config']['stage_root']),
                                               application_registrar.HbaseApplicationRegistrar(
+                                                  config['environment']['hbase_thrift_server']),
+                                              application_summary_registrar.HBaseAppplicationSummary(
                                                   config['environment']['hbase_thrift_server']),
                                               config['environment'],
                                               config['config'])

--- a/api/src/main/resources/application_summary.py
+++ b/api/src/main/resources/application_summary.py
@@ -1,0 +1,605 @@
+import json
+import multiprocessing
+import time
+import logging
+import sys
+import requests
+
+import application_registrar
+import deployer_utils
+import application_summary_registrar
+from lifecycle_states import ApplicationState
+
+CONFIG = None
+YARN_RESOURCE_MANAGER = None
+YARN_PORT = None
+OOZIE_URI = None
+_APPLICATION_REGISTRAR = None
+_HBASE = None
+_MAX_PROCESS_COUNT = 4
+_MAX_TIME_BOUND = 60
+_MAX_PROCESS_TIME = 6
+COMPONENT_STATUS = dict([("green", "OK"), ("amber", "WARN"), ("red", "ERROR")])
+ERROR_STATUS = dict([("OK", "WITH_NO_ERRORS"), ("ERROR", "WITH_ERRORS"), ("WARN", "WITH_ERRORS")])
+FAILURE_STATUS = dict([("OK", "WITH_NO_FAILURES"), ("ERROR", "WITH_FAILURES"), \
+("WARN", "WITH_FAILURES")])
+
+# pylint: disable=R0204
+def spark_job_handler(app_id):
+    """
+    Find Job and Stage status of Spark Application
+    """
+    ret = {}
+    state = None
+    information = None
+    try:
+        url = 'http://%s:%s%s%s%s%s%s' % (YARN_RESOURCE_MANAGER, YARN_PORT, \
+        '/proxy/', app_id, '/api/v1/applications/', app_id, '/jobs')
+        spark_jobs = requests.get(url, timeout=_MAX_PROCESS_TIME)
+        try:
+            spark_jobs = json.loads(spark_jobs.text)
+            if spark_jobs:
+                information = {}
+                job_count = len(spark_jobs)
+                job_suc_c, job_unknown_c, job_fail_c, job_run_c = (0, 0, 0, 0)
+                for ele in spark_jobs:
+                    if ele['status'] == 'RUNNING':
+                        job_run_c += 1
+                    if ele['status'] == 'SUCCEEDED':
+                        job_suc_c += 1
+                    if ele['status'] == 'UNKNOWN':
+                        job_unknown_c += 1
+                    if ele['status'] == 'FAILED':
+                        job_fail_c += 1
+                url = 'http://%s:%s%s%s%s%s%s' % (YARN_RESOURCE_MANAGER, YARN_PORT, '/proxy/', \
+                app_id, '/api/v1/applications/', app_id, '/stages')
+                spark_stages = requests.get(url)
+                spark_stages = json.loads(spark_stages.text)
+                stage_count = len(spark_stages)
+                stage_complete_c, stage_active_c, stage_pending_c, stage_failed_c = (0, 0, 0, 0)
+                for ele in spark_stages:
+                    if ele['status'] == 'COMPLETE':
+                        stage_complete_c += 1
+                    if ele['status'] == 'ACTIVE':
+                        stage_active_c += 1
+                    if ele['status'] == 'PENDING':
+                        stage_pending_c += 1
+                    if ele['status'] == 'FAILED':
+                        stage_failed_c += 1
+                information = {
+                    'jobSummary': {'number_of_jobs': job_count, 'unknown': job_unknown_c, \
+                    'succeeded': job_suc_c, 'failed': job_fail_c, 'running': job_run_c},
+                    'stageSummary': {'number_of_stages': stage_count, 'active': stage_active_c, \
+                    'complete': stage_complete_c, 'pending': stage_pending_c, \
+                    'failed': stage_failed_c}
+                }
+                if job_fail_c >= 1:
+                    state = COMPONENT_STATUS['red']
+                else:
+                    state = COMPONENT_STATUS['green']
+            else:
+                state = COMPONENT_STATUS['red']
+                information = 'No Jobs available'
+        except ValueError as error_message:
+            state = COMPONENT_STATUS['red']
+            information = str(error_message)
+    except requests.exceptions.Timeout as error_message:
+        state = COMPONENT_STATUS['red']
+        information = str(error_message)
+    ret.update({
+        'state': state,
+        'information': information
+    })
+    return ret
+
+def convert_job_id(job_id):
+    """
+    Replace keyword job with application to pass it to yarn and spark server
+    """
+    job_id = job_id.split('_')
+    job_id[0] = 'application'
+    job_id = '_'.join(job_id)
+    return job_id
+
+def yarn_info(app_id):
+    """
+    Get YARN information for a Job Id
+    """
+    url = 'http://%s:%s%s/%s' % (YARN_RESOURCE_MANAGER, YARN_PORT, '/ws/v1/cluster/apps', app_id)
+    ret = {}
+    try:
+        yarn_app_info = requests.get(url, timeout=_MAX_PROCESS_TIME)
+        try:
+            yarn_app_info = json.loads(yarn_app_info.text)
+            if 'app' in yarn_app_info:
+                ret.update({
+                    'yarnStatus': yarn_app_info['app']['state'],
+                    'yarnFinalStatus': yarn_app_info['app']['finalStatus'],
+                    'startedTime': yarn_app_info['app']['startedTime'],
+                    'type': yarn_app_info['app']['applicationType']
+                })
+            else:
+                message = yarn_app_info['RemoteException']['message'].split(':')
+                message[0] = ''
+                message = ''.join(message).strip()
+                ret.update({'information': message, 'yarnStatus': 'NOT FOUND', \
+                'yarnFinalStatus': 'UNKNOWN', 'type': 'UNKNOWN'})
+        except ValueError as error_message:
+            logging.debug(str(error_message))
+    except requests.exceptions.Timeout as error_message:
+        logging.debug(str(error_message))
+    return ret
+
+def find_workflow_type(actions):
+    """
+    To find workflow type
+    """
+    type_name = 'workflow'
+    for action in actions:
+        if action['type'] == 'sub-workflow':
+            type_name = 'subworkflow'
+            break
+    return type_name
+
+# pylint: disable=R0101
+
+def get_oozie_workflow_actions(actions):
+    """
+    Handling OOZIE actions both Workflow and Coordinator
+    """
+    count = 1
+    ret = {}
+    for action in actions:
+        if action['externalId'] != None:
+            if 'job_' in action['externalId']:
+                launcher_id = convert_job_id(action['externalId'])
+                launcher_job = yarn_info(launcher_id)
+                yarnid = launcher_id
+                information = None
+                applicationtype = launcher_job['type']
+                if launcher_job['yarnStatus'] == 'KILLED' or \
+                launcher_job['yarnFinalStatus'] == 'FAILED':
+                    status = COMPONENT_STATUS['red']
+                elif launcher_job['yarnStatus'] == 'RUNNING' or launcher_job['yarnStatus'] \
+                == 'FINISHED' or launcher_job['yarnStatus'] == 'ACCEPTED':
+                    status = COMPONENT_STATUS['green']
+                    if action['externalChildIDs']:
+                        actual_job_id = convert_job_id(action['externalChildIDs'])
+                        actual_job = yarn_info(actual_job_id)
+                        yarnid = actual_job_id
+                        applicationtype = actual_job['type']
+                        if actual_job['yarnStatus'] == 'KILLED' or \
+                        actual_job['yarnFinalStatus'] == 'FAILED':
+                            status = COMPONENT_STATUS['red']
+                        elif action['type'] == 'spark':
+                            spark_job = spark_job_handler(actual_job_id)
+                            if spark_job['state'] == 'ERROR':
+                                status = COMPONENT_STATUS['red']
+                                information = spark_job['information']
+                            else:
+                                status = COMPONENT_STATUS['green']
+                                information = spark_job['information']
+                        else:
+                            status = COMPONENT_STATUS['green']
+                else:
+                    status = COMPONENT_STATUS['red']
+                    information = launcher_job['information']
+                ret.update({"%s-%d" % ("job", count):{
+                    'status': status,
+                    'yarnId': yarnid,
+                    'information': information,
+                    'name': action['name'],
+                    'applicationType': applicationtype
+                }})
+                count += 1
+            if 'oozie-oozi-W' in action['externalId']:
+                type_name = find_workflow_type(actions)
+                key = '%s-%d' % (type_name, count)
+                count += 1
+                oozie_info = oozie_api_request(action['externalId'])
+                oozie_data = get_oozie_workflow_actions(oozie_info['actions'])
+                workflowstatus = process_component_data(oozie_data)
+                if action['status'] == 'ERROR' or action['status'] == 'FAILED' \
+                or action['status'] == 'KILLED':
+                    action_status = COMPONENT_STATUS['red']
+                else:
+                    action_status = COMPONENT_STATUS['green']
+                if action_status == 'OK' and workflowstatus == 'OK':
+                    status = COMPONENT_STATUS['green']
+                elif action_status == 'OK' and workflowstatus == 'WARN':
+                    status = COMPONENT_STATUS['amber']
+                else:
+                    status = COMPONENT_STATUS['red']
+                ret.update({key: {'actions': oozie_data, 'oozieId': action['externalId'], \
+                'status': status, 'name': oozie_info['appName']}})
+    return ret
+
+def process_component_data(data):
+    """
+    Process multiple Jobs or Subworkflows or Workflows data to find aggregate status
+    """
+    error_count, action_count, warn_count = (0, 0, 0)
+    for ele in data:
+        action_count += 1
+        if data[ele]['status'] == 'ERROR':
+            error_count += 1
+        if data[ele]['status'] == 'WARN':
+            warn_count += 1
+    if error_count == 0:
+        if warn_count >= 1:
+            status = COMPONENT_STATUS['amber']
+        else:
+            status = COMPONENT_STATUS['green']
+    elif error_count == action_count:
+        status = COMPONENT_STATUS['red']
+    else:
+        status = COMPONENT_STATUS['amber']
+    return status
+
+def oozie_api_request(job_id):
+    """
+    Get OOZIE information for OOZIE Job Id
+    """
+    oozie_info = {}
+    url = '%s%s%s' % (OOZIE_URI, '/v1/job/', job_id)
+    try:
+        oozie_info = requests.get(url, timeout=_MAX_PROCESS_TIME)
+        try:
+            oozie_info = json.loads(oozie_info.text)
+        except ValueError as error_message:
+            logging.debug(str(error_message))
+    except requests.exceptions.Timeout as error_message:
+        logging.debug(str(error_message))
+    return oozie_info
+
+def oozie_coordinator_handler(data):
+    """
+    Handling OOZIE-COORDINATOR
+    """
+    coord_status = {}
+    if data['status'] == 'PREPSUSPENDED':
+        coord_status.update({'aggregate_status': ApplicationState.CREATED, \
+        'name': data['coordJobName']})
+    elif data['status'] == 'PREP':
+        coord_status.update({'aggregate_status': ApplicationState.STARTING, \
+        'name': data['coordJobName']})
+    elif data['status'] == 'RUNNING':
+        oozie_data = get_oozie_workflow_actions(data['actions'])
+        aggregate_status = process_component_data(oozie_data)
+        coord_status.update({'actions': oozie_data, 'status': aggregate_status, 'aggregate_status':\
+        '%s_%s_%s' % (ApplicationState.STARTED, 'RUNNING', ERROR_STATUS[aggregate_status]), \
+        'oozieId': data['coordJobId'], 'name': data['coordJobName']})
+    elif data['status'] == 'SUSPENDED':
+        oozie_data = get_oozie_workflow_actions(data['actions'])
+        aggregate_status = process_component_data(oozie_data)
+        coord_status.update({'actions': oozie_data, 'status': aggregate_status, 'aggregate_status':\
+        '%s_%s_%s' % (ApplicationState.COMPLETED, 'SUSPENDED', FAILURE_STATUS[aggregate_status]), \
+        'oozieId': data['coordJobId'], 'name': data['coordJobName']})
+    elif data['status'] == 'KILLED':
+        oozie_data = get_oozie_workflow_actions(data['actions'])
+        aggregate_status = process_component_data(oozie_data)
+        coord_status.update({'actions': oozie_data, 'status': aggregate_status, 'aggregate_status':\
+        '%s_%s_%s' % (ApplicationState.COMPLETED, 'KILLED', FAILURE_STATUS[aggregate_status]), \
+        'oozieId': data['coordJobId'], 'name': data['coordJobName']})
+    return coord_status
+
+def oozie_workflow_handler(data):
+    """
+    Handling OOZIE-WORKFLOW
+    """
+    workflow_status = {}
+    if data['status'] == 'PREP':
+        workflow_status.update({'aggregate_status': ApplicationState.CREATED, \
+        'name': data['appName']})
+    elif data['status'] == 'RUNNING':
+        oozie_data = get_oozie_workflow_actions(data['actions'])
+        aggregate_status = process_component_data(oozie_data)
+        workflow_status.update({'actions': oozie_data, 'aggregate_status': '%s_%s_%s' % \
+        (ApplicationState.STARTED, 'RUNNING', ERROR_STATUS[aggregate_status]), \
+        'oozieId': data['id'], 'name': data['appName'], 'status': aggregate_status})
+    elif data['status'] == 'SUSPENDED':
+        oozie_data = get_oozie_workflow_actions(data['actions'])
+        aggregate_status = process_component_data(oozie_data)
+        workflow_status.update({'actions': oozie_data, 'aggregate_status': '%s_%s_%s' % \
+        (ApplicationState.COMPLETED, 'SUSPENDED', FAILURE_STATUS[aggregate_status]), \
+        'oozieId': data['id'], 'name': data['appName'], 'status': aggregate_status})
+    elif data['status'] == 'KILLED':
+        oozie_data = get_oozie_workflow_actions(data['actions'])
+        aggregate_status = process_component_data(oozie_data)
+        workflow_status.update({'actions': oozie_data, 'aggregate_status': '%s_%s_%s' % \
+        (ApplicationState.COMPLETED, 'KILLED', FAILURE_STATUS[aggregate_status]), \
+        'oozieId': data['id'], 'name': data['appName'], 'status': aggregate_status})
+    return workflow_status
+
+def oozie_application(job_handle):
+    """
+    Handling OOZIE Application
+    """
+    oozie_info = oozie_api_request(job_handle)
+    if 'coordJobName' in oozie_info:
+        return oozie_coordinator_handler(oozie_info)
+    if 'appName' in oozie_info:
+        return oozie_workflow_handler(oozie_info)
+
+def compare_yarn_start_time(app_info):
+    """
+    returns startedTime
+    """
+    return app_info['startedTime']
+
+def check_in_yarn(job_name):
+    """
+    Check in YARN list of Jobs with Job name provided and return latest application
+    """
+    url = 'http://%s:%s%s' % (YARN_RESOURCE_MANAGER, YARN_PORT, '/ws/v1/cluster/apps')
+    run_app_info = None
+    try:
+        yarn_list = requests.get(url, timeout=_MAX_PROCESS_TIME)
+        try:
+            yarn_list = json.loads(yarn_list.text)
+            if yarn_list['apps'] != None:
+                for app in yarn_list['apps']['app']:
+                    if job_name == app['name']:
+                        if run_app_info is None or compare_yarn_start_time(app) > \
+                        compare_yarn_start_time(run_app_info):
+                            run_app_info = app
+        except ValueError as error_message:
+            logging.debug(str(error_message))
+    except requests.exceptions.Timeout as error_message:
+        logging.debug(str(error_message))
+    return run_app_info
+
+def spark_application(job_name):
+    """
+    Handling SPARK Application
+    """
+    new_app_flag = False
+    ret = {}
+    information = None
+    app_id = check_in_yarn(job_name)
+    if app_id != None:
+        yarn_data = yarn_info(app_id['id'])
+        if yarn_data['yarnFinalStatus'] == 'FAILED':
+            aggregate_status = '%s_%s_%s' % (ApplicationState.COMPLETED, \
+            'FAILED', FAILURE_STATUS['ERROR'])
+        elif yarn_data['yarnFinalStatus'] == 'KILLED':
+            aggregate_status = '%s_%s_%s' % (ApplicationState.COMPLETED, \
+            'KILLED', FAILURE_STATUS['OK'])
+        elif yarn_data['yarnStatus'] == 'RUNNING':
+            spark_data = spark_job_handler(app_id['id'])
+            aggregate_status = '%s_%s_%s' % (ApplicationState.STARTED, \
+            yarn_data['yarnStatus'], ERROR_STATUS[spark_data['state']])
+            information = spark_data['information']
+        elif yarn_data['yarnStatus'] == 'FINISHED' and yarn_data['yarnFinalStatus'] == 'SUCCEEDED':
+            aggregate_status = '%s_%s_%s' % (ApplicationState.COMPLETED, \
+            yarn_data['yarnStatus'], ERROR_STATUS['OK'])
+        elif yarn_data['yarnStatus'] == 'NOT FOUND':
+            aggregate_status = '%s_%s_%s' % (ApplicationState.COMPLETED, \
+            yarn_data['yarnStatus'], ERROR_STATUS['ERROR'])
+            information = yarn_data['information']
+        else:
+            aggregate_status = '%s_%s_%s' % (ApplicationState.STARTED, \
+            yarn_data['yarnStatus'], ERROR_STATUS['OK'])
+        ret = {
+            'aggregate_status': aggregate_status,
+            'yarnId': app_id['id'],
+            'information': information,
+            'name': job_name
+        }
+    else:
+        new_app_flag = True
+    if new_app_flag:
+        ret = {
+            'aggregate_status': ApplicationState.CREATED,
+            'information': information,
+            'name': job_name
+        }
+    return ret
+
+def get_json(component_list, queue_obj):
+    """
+    Processing Components and return generated Component data
+    """
+    process_name = multiprocessing.current_process().name
+    logging.info('%s %s', 'Starting', process_name)
+    ret = {}
+    for component in component_list:
+        for application in component:
+            if application not in ret.keys():
+                ret.update({application: {}})
+            for component_name in component[application]:
+                if 'oozie' in component_name:
+                    ret[application].update({component_name: oozie_application\
+                    (component[application][component_name]['job_handle'])})
+                if 'sparkStreaming' in component_name:
+                    ret[application].update({component_name: spark_application\
+                    (component[application][component_name]['component_job_name'])})
+    queue_obj.put([{process_name: ret}])
+    logging.info('%s %s', 'Finished', process_name)
+
+def combine_data(summarydata):
+    """
+    Combine components into application level
+    """
+    application_data = {}
+    for process in summarydata:
+        for app in summarydata[process]:
+            if app not in application_data.keys():
+                application_data.update({app: {}})
+            for component in summarydata[process][app]:
+                application_data[app].update({component: summarydata[process][app][component]})
+    return application_data
+
+def split_application_components(alist, split_c):
+    """
+    Split Components of application across processes based on process count
+    """
+    applist = [[] for _ in range(split_c)]
+    index = 0
+    for app in alist:
+        create_data = _APPLICATION_REGISTRAR.get_create_data(app)
+        if 'oozie' in create_data:
+            for count, oozie_component in enumerate(create_data['oozie']):
+                applist[index].append({app: {
+                    '%s-%d' % ('oozie', (count+1)): oozie_component
+                }})
+                index = (index + 1) % split_c
+        if 'sparkStreaming' in create_data:
+            for count, spark_component in enumerate(create_data['sparkStreaming']):
+                applist[index].append({app: {
+                    '%s-%d' % ('sparkStreaming', (count+1)): spark_component
+                }})
+                index = (index + 1) % split_c
+    return applist
+
+def find_split_count(applist):
+    """
+    Find process count based on all applications component's count
+    """
+    (component_count, oozie_component_count, spark_component_count) = (0, 0, 0)
+    split_count = 1
+    for application in  applist:
+        create_data = _APPLICATION_REGISTRAR.get_create_data(application)
+        if 'oozie' in create_data:
+            oozie_component_count = len(create_data['oozie'])
+        if 'sparkStreaming' in create_data:
+            spark_component_count = len(create_data['sparkStreaming'])
+        component_count += oozie_component_count + spark_component_count
+        (oozie_component_count, spark_component_count) = (0, 0)
+    process_count = (component_count * _MAX_PROCESS_TIME)/_MAX_TIME_BOUND
+    if process_count > _MAX_PROCESS_COUNT:
+        split_count = _MAX_PROCESS_COUNT
+    elif process_count >= 1:
+        split_count = process_count
+    return split_count
+
+def process_application_data(application):
+    """
+    Find Application level aggregated status based on it's component's status
+    """
+    (current_agg_status_priority, current_error_status_priority, \
+    current_failure_status_priority) = (99, 99, 99)
+    aggregated_status_priority = dict([(ApplicationState.CREATED, 1), \
+    (ApplicationState.STARTING, 2), (ApplicationState.STARTED, 3), (ApplicationState.COMPLETED, 4)])
+    error_status_priority = dict([('ERRORS', 1), ('NO_ERRORS', 2)])
+    failure_status_priority = dict([('FAILURES', 1), ('NO_FAILURES', 2)])
+    for component in application:
+        if current_agg_status_priority >= aggregated_status_priority[application[component]\
+        ['aggregate_status'].split('_')[0]]:
+            current_agg_status_priority = aggregated_status_priority[application[component]\
+            ['aggregate_status'].split('_')[0]]
+        temp = application[component]['aggregate_status'].split('WITH_')[-1]
+        if 'ERRORS' in temp:
+            if current_error_status_priority >= error_status_priority[temp]:
+                current_error_status_priority = error_status_priority[temp]
+        if 'FAILURES' in temp:
+            if current_failure_status_priority >= failure_status_priority[temp]:
+                current_failure_status_priority = failure_status_priority[temp]
+
+    if current_agg_status_priority == 3:
+        if current_error_status_priority == 2:
+            if current_failure_status_priority == 1:
+                error_status = 'ERRORS'
+            else:
+                error_status = 'NO_ERRORS'
+        else:
+            error_status = 'ERRORS'
+        aggregated_status = '%s_%s_WITH_%s' % (ApplicationState.STARTED, 'RUNNING', error_status)
+    elif current_agg_status_priority == 4:
+        if current_failure_status_priority == 1:
+            failure_status = 'FAILURES'
+        else:
+            failure_status = 'NO_FAILURES'
+        aggregated_status = '%s_WITH_%s' % (ApplicationState.COMPLETED, failure_status)
+    elif current_agg_status_priority == 1:
+        aggregated_status = ApplicationState.CREATED
+    else:
+        aggregated_status = ApplicationState.STARTING
+    return aggregated_status
+
+def application_summary(app_list):
+    """
+    application_summary
+    """
+    _HBASE.remove_app_entry(app_list)
+    if app_list:
+        logging.info('%d-%s', len(app_list), 'Applications found')
+        processes = []
+        summary_data = {}
+        split_count = find_split_count(app_list)
+        logging.info('%d %s', split_count, 'Processes will be created and they will be \
+processed in multiprocess environment')
+        split_app_list = split_application_components(app_list, split_count)
+        queue_obj = multiprocessing.Queue()
+        for i, app in enumerate(split_app_list):
+            process = multiprocessing.Process(name='%s-%d' %('process', i), \
+            target=get_json, args=(app, queue_obj,))
+            processes.append(process)
+            process.start()
+        total_time = _MAX_TIME_BOUND
+        for process in processes:
+            start_time = time.time()
+            process.join(timeout=total_time)
+            try:
+                summary_data.update(queue_obj.get(block=False)[0])
+            except multiprocessing.queues.Empty:
+                pass
+            total_time = total_time - int(time.time() - start_time)
+        applications = combine_data(summary_data)
+        for application in applications:
+            aggregate_status = process_application_data(applications[application])
+            applications[application].update({'aggregate_status': aggregate_status})
+            logging.info("%s%s%s", application, "'s aggregate status is ", aggregate_status)
+        _HBASE.post_to_hbase(applications)
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+        logging.info('All processes finished')
+    else:
+        logging.info('No application found')
+
+# pylint: disable=C0103
+# pylint: disable=W0603
+
+def main():
+    """
+    main
+    """
+    global CONFIG
+    global YARN_RESOURCE_MANAGER
+    global YARN_PORT
+    global OOZIE_URI
+    global _APPLICATION_REGISTRAR
+    global _HBASE
+
+    with open('dm-config.json', 'r') as conf:
+        CONFIG = json.load(conf)
+
+    logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s',
+                        level=logging.getLevelName(CONFIG['config']['log_level']),
+                        stream=sys.stderr)
+    logging.info('Starting... Building actual status for applications')
+    deployer_utils.fill_hadoop_env(CONFIG['environment'])
+    _APPLICATION_REGISTRAR = application_registrar.HbaseApplicationRegistrar\
+    (CONFIG['environment']['hbase_thrift_server'])
+    _HBASE = application_summary_registrar.HBaseAppplicationSummary\
+    (CONFIG['environment']['hbase_thrift_server'])
+    YARN_RESOURCE_MANAGER = CONFIG['environment']['yarn_resource_manager_host']
+    YARN_PORT = CONFIG['environment']['yarn_resource_manager_port']
+    OOZIE_URI = CONFIG['environment']['oozie_uri']
+    prev_run_app_list = []
+    while True:
+        start_time = time.time()
+        app_list = _APPLICATION_REGISTRAR.list_applications()
+        application_summary(app_list)
+        prev_run_app_list = app_list
+        wait_time = _MAX_TIME_BOUND - int(time.time() - start_time)
+        app_list = _APPLICATION_REGISTRAR.list_applications()
+        if set(app_list).difference(prev_run_app_list) == set([]) \
+        and set(prev_run_app_list).difference(app_list) == set([]):
+            time.sleep(wait_time)
+        else:
+            continue
+
+if __name__ == "__main__":
+    main()

--- a/api/src/main/resources/application_summary_registrar.py
+++ b/api/src/main/resources/application_summary_registrar.py
@@ -1,0 +1,101 @@
+import json
+import logging
+import happybase
+from Hbase_thrift import AlreadyExists
+
+#pylint: disable=E0602
+
+class HBaseAppplicationSummary(object):
+    def __init__(self, hbase_host):
+        self._hbase_host = hbase_host
+        self._table_name = 'platform_application_summary'
+        if self._hbase_host is not None:
+            try:
+                connection = happybase.Connection(self._hbase_host)
+                connection.create_table(self._table_name, {'cf': dict()})
+            except AlreadyExists as error_message:
+                logging.info(str(error_message))
+            except thriftpy.transport.TTransportException as error_message:
+                logging.debug(str(error_message))
+            finally:
+                connection.close()
+
+    def remove_app_entry(self, app_list):
+        connection = None
+        try:
+            connection = happybase.Connection(self._hbase_host)
+            table = connection.table(self._table_name)
+            for application, _ in table.scan():
+                if application not in app_list:
+                    table.delete(application)
+        except thriftpy.transport.TTransportException as error_message:
+            logging.debug(str(error_message))
+        finally:
+            connection.close()
+
+    def write_to_hbase(self, application, summary):
+        connection = None
+        try:
+            connection = happybase.Connection(self._hbase_host)
+            table = connection.table(self._table_name)
+            table.put(application, summary)
+        except thriftpy.transport.TTransportException as error_message:
+            logging.debug(str(error_message))
+        finally:
+            connection.close()
+
+    def post_to_hbase(self, app_summary):
+        for application in app_summary:
+            data = {}
+            for component in app_summary[application]:
+                if 'aggregate_status' not in component:
+                    data.update({component: app_summary[application][component]})
+            data = {
+                '%s:%s' % ('cf', 'component_data'): json.dumps(data),
+                '%s:%s' % ('cf', 'aggregate_status'): app_summary[application]['aggregate_status']
+            }
+            self.write_to_hbase(application, data)
+
+    def _read_from_db(self, key):
+        connection = None
+        try:
+            connection = happybase.Connection(self._hbase_host)
+            table = connection.table(self._table_name)
+            data = table.row(key)
+        except thriftpy.transport.TTransportException as error_message:
+            logging.debug(str(error_message))
+        finally:
+            connection.close()
+        return data
+
+    def get_dm_data(self, key):
+        connection = None
+        try:
+            connection = happybase.Connection(self._hbase_host)
+            table = connection.table("platform_applications")
+            data = table.row(key)
+        except thriftpy.transport.TTransportException as error_message:
+            logging.debug(str(error_message))
+        finally:
+            connection.close()
+        return data
+
+    def get_summary_data(self, application):
+        record = {application: {}}
+        dm_data = self.get_dm_data(application)
+        if dm_data:
+            summary_data = self._read_from_db(application)
+            if summary_data:
+                record[application].update({
+                    'aggregate_status': summary_data['cf:aggregate_status']
+                })
+                record[application].update(json.loads(summary_data['cf:component_data']))
+            else:
+                record[application].update({
+                    'status': 'Not Available'
+                })
+        else:
+            record[application].update({
+                'status': 'Not Created'
+            })
+        return record

--- a/api/src/main/resources/deployment_manager.py
+++ b/api/src/main/resources/deployment_manager.py
@@ -41,7 +41,7 @@ def milli_time():
 
 
 class DeploymentManager(object):
-    def __init__(self, repository, package_registrar, application_registrar, environment, config):
+    def __init__(self, repository, package_registrar, application_registrar, application_summary_registrar, environment, config):
         self._repository = repository
         self._package_registrar = package_registrar
         self._application_registrar = application_registrar
@@ -49,6 +49,7 @@ class DeploymentManager(object):
         self._config = config
         self._application_creator = application_creator.ApplicationCreator(config, environment,
                                                                            environment['namespace'])
+        self._application_summary_registrar = application_summary_registrar
         self._package_parser = PackageParser()
         self._package_progress = {}
         self._lock = threading.RLock()
@@ -347,6 +348,11 @@ class DeploymentManager(object):
         record = self._application_creator.get_application_runtime_details(application, create_data)
         record['status'] = self.get_application_info(application)['status']
         record['name'] = application
+        return record
+
+    def get_application_summary(self, application):
+        logging.info('get_application_summary')
+        record = self._application_summary_registrar.get_summary_data(application)
         return record
 
     def create_application(self, package, application, overrides):

--- a/api/src/main/resources/lifecycle_states.py
+++ b/api/src/main/resources/lifecycle_states.py
@@ -36,3 +36,4 @@ class ApplicationState(object):
     STARTED = "STARTED"
     STOPPING = "STOPPING"
     NOTCREATED = "NOTCREATED"
+    COMPLETED = "COMPLETED"

--- a/api/src/main/resources/test_application_summary.py
+++ b/api/src/main/resources/test_application_summary.py
@@ -1,0 +1,490 @@
+import json
+import unittest
+from mock import patch
+import application_summary
+from lifecycle_states import ApplicationState
+COMPONENT_STATUS = dict([("green", "OK"), ("amber", "WARN"), ("red", "ERROR")])
+ERROR_STATUS = dict([("OK", "WITH_NO_ERRORS"), ("ERROR", "WITH_ERRORS"), ("WARN", "WITH_ERRORS")])
+FAILURE_STATUS = dict([("OK", "WITH_NO_FAILURES"), ("ERROR", "WITH_FAILURES"), \
+("WARN", "WITH_FAILURES")])
+
+class AppplicationSummaryTests(unittest.TestCase):
+    def test_process_application_data(self):
+        """
+        Check building aggregate status works on application level from component level
+        """
+        result = application_summary.process_application_data({'component-1': \
+        {'aggregate_status': 'STARTED_RUNNING_WITH_NO_ERRORS', 'yarnId': '1234'}})
+        self.assertEqual(result, 'STARTED_RUNNING_WITH_NO_ERRORS')
+
+    @patch('application_summary.check_in_yarn')
+    @patch('application_summary.yarn_info')
+    @patch('application_summary.spark_job_handler')
+    def test_spark_application(self, spark_job_patch, yarn_job_patch, yarn_check_patch):
+        """
+        Tetsing Spark application
+        """
+        #Spark application in case of Killed
+        yarn_check_patch.return_value = {'id': 'application_1234'}
+        yarn_job_patch.return_value = {'yarnFinalStatus': 'KILLED'}
+        result = application_summary.spark_application('app1-example-job')
+        self.assertEqual(result['aggregate_status'], '%s_%s_%s' % (ApplicationState.COMPLETED, \
+        'KILLED', FAILURE_STATUS['OK']))
+
+        #Spark application in case of Failed
+        yarn_check_patch.return_value = {'id': 'application_1234'}
+        yarn_job_patch.return_value = {'yarnFinalStatus': 'FAILED'}
+        result = application_summary.spark_application('app1-example-job')
+        self.assertEqual(result['aggregate_status'], '%s_%s_%s' % (ApplicationState.COMPLETED, \
+        'FAILED', FAILURE_STATUS['ERROR']))
+
+        #Spark application in case of Running with No errors
+        yarn_check_patch.return_value = {'id': 'application_1234'}
+        yarn_job_patch.return_value = {'yarnStatus': 'RUNNING', \
+        'yarnFinalStatus': 'UNDEFINED'}
+        spark_job_patch.return_value = {'state': 'OK', 'information': 'job_stage data'}
+        result = application_summary.spark_application('app1-example-job')
+        self.assertEqual(result['aggregate_status'], '%s_%s_%s' % (ApplicationState.STARTED, \
+        'RUNNING', ERROR_STATUS['OK']))
+
+        #Spark application in case of Running with errors
+        yarn_check_patch.return_value = {'id': 'application_1234'}
+        yarn_job_patch.return_value = {'yarnStatus': 'RUNNING', \
+        'yarnFinalStatus': 'UNDEFINED'}
+        spark_job_patch.return_value = {'state': 'ERROR', 'information': 'job_stage data'}
+        result = application_summary.spark_application('app1-example-job')
+        self.assertEqual(result['aggregate_status'], '%s_%s_%s' % (ApplicationState.STARTED, \
+        'RUNNING', ERROR_STATUS['ERROR']))
+
+        #Spark application in other states than above states
+        yarn_check_patch.return_value = {'id': 'application_1234'}
+        yarn_job_patch.return_value = {'yarnStatus': 'ACCEPTED', \
+        'yarnFinalStatus': 'UNDEFINED'}
+        result = application_summary.spark_application('app1-example-job')
+        self.assertEqual(result['aggregate_status'], '%s_%s_%s' % (ApplicationState.STARTED, \
+        'ACCEPTED', ERROR_STATUS['OK']))
+
+    @patch('requests.get')
+    def test_check_in_yarn(self, mock_req):
+        """
+        Check recent application data provided or not based on started time
+        """
+        mock_req.return_value = type('obj', (object,), {'status_code' : 200, 'text': json.dumps({
+            "apps": {
+                "app": [
+                    {
+                        "name": "app1-example-job",
+                        "id": "application_1234",
+                        "startedTime": 1512647193214
+                    },
+                    {
+                        "name": "app1-example-job",
+                        "id": "application_1235",
+                        "startedTime": 1512647212310
+                    },
+                    {
+                        "name": "app1-example-job",
+                        "id": "application_1236",
+                        "startedTime": 1512647185041
+                    }
+                ]
+            }
+        })})
+        result = application_summary.check_in_yarn('app1-example-job')
+        self.assertEqual(result['id'], 'application_1235')
+
+    @patch('application_summary.process_component_data')
+    @patch('application_summary.get_oozie_workflow_actions')
+    def test_oozie_coordinator_handler(self, oozie_worfklow_patch, process_component_data_patch):
+        """
+        Testing Oozie Coordinator
+        """
+        #Oozie Coordinator in case of Prepsuspended
+        result = application_summary.oozie_coordinator_handler({
+            'actions': [],
+            'coordJobId': '0123-oozie-oozi-C',
+            'coordJobName': 'o1-coordinator',
+            'status': 'PREPSUSPENDED'
+        })
+        self.assertEqual(result['aggregate_status'], ApplicationState.CREATED)
+
+        #Oozie Coordinator in case of Prep
+        result = application_summary.oozie_coordinator_handler({
+            'actions': [],
+            'coordJobId': '0123-oozie-oozi-C',
+            'coordJobName': 'o1-coordinator',
+            'status': 'PREP'
+        })
+        self.assertEqual(result['aggregate_status'], ApplicationState.STARTING)
+
+        #Oozie Coordinator in case of Running and one workflow in WARN state
+        oozie_worfklow_patch.return_value = {
+            'workflow-1': {
+                'status': 'WARN',
+                'oozieId': '0123-oozie-oozi-W',
+                'actions': {},
+                'name': 'o1-workflow'
+            }
+            }
+        process_component_data_patch.return_value = 'ERROR'
+        result = application_summary.oozie_coordinator_handler({
+            'actions': [{
+                'externalId': '0123-oozi-W',
+                'coordJobId': '0123-oozi-C'
+            }],
+            'coordJobId': '0123-oozie-oozi-C',
+            'coordJobName': 'o1-coordinator',
+            'status': 'RUNNING'
+        })
+        self.assertEqual(result['aggregate_status'], '%s_%s_%s' % \
+        (ApplicationState.STARTED, 'RUNNING', ERROR_STATUS['WARN']))
+
+        #Oozie Coordinator in case of Suspended and Workflow in OK state
+        oozie_worfklow_patch.return_value = {
+            'workflow-1': {
+                'status': 'OK',
+                'oozieId': '0123-oozie-oozi-W',
+                'actions': {},
+                'name': 'o1-workflow'
+            }
+            }
+        process_component_data_patch.return_value = 'OK'
+        result = application_summary.oozie_coordinator_handler({
+            'actions': [{
+                'externalId': '0123-oozie-oozi-W',
+                'coordJobId': '0123-oozie-oozi-C'
+            }],
+            'coordJobId': '0123-oozie-oozi-C',
+            'coordJobName': 'o1-coordinator',
+            'status': 'SUSPENDED'
+        })
+        self.assertEqual(result['aggregate_status'], '%s_%s_%s' \
+        % (ApplicationState.COMPLETED, 'SUSPENDED', FAILURE_STATUS['OK']))
+
+        #Oozie Coordinator in case of Killed and one workflow in ERROR state
+        oozie_worfklow_patch.return_value = {
+            'workflow-1': {
+                'status': 'ERROR',
+                'oozieId': '0123-oozie-oozi-W',
+                'actions': {},
+                'name': 'o1-workflow'
+            }
+            }
+        process_component_data_patch.return_value = 'ERROR'
+        result = application_summary.oozie_coordinator_handler({
+            'actions': [{
+                'externalId': '0123-oozie-oozi-W',
+                'coordJobId': '0123-oozie-oozi-C'
+            }],
+            'coordJobId': '0123-oozie-oozi-C',
+            'coordJobName': 'o1-coordinator',
+            'status': 'KILLED'
+        })
+        self.assertEqual(result['aggregate_status'], '%s_%s_%s' \
+        % (ApplicationState.COMPLETED, 'KILLED', FAILURE_STATUS['ERROR']))
+
+    @patch('application_summary.process_component_data')
+    @patch('application_summary.get_oozie_workflow_actions')
+    def test_oozie_workflow_handler(self, oozie_worfklow_patch, process_component_data_patch):
+        """
+        Testing Oozie Workflow
+        """
+        #Oozie Workflow in case of Prep
+        result = application_summary.oozie_workflow_handler({
+            'actions': [],
+            'id': '0123-oozie-oozi-W',
+            'appName': 'o2-workflow',
+            'status': 'PREP'
+        })
+        self.assertEqual(result['aggregate_status'], ApplicationState.CREATED)
+
+        #Oozie Workflow in case of Running and one job in ERROR state
+        oozie_worfklow_patch.return_value = {
+            'job-1': {
+                'status': 'ERROR',
+                'yarnId': 'application_1234',
+                'name': 'process'
+            }
+            }
+        process_component_data_patch.return_value = 'ERROR'
+        result = application_summary.oozie_workflow_handler({
+            'actions': [{
+                'externalId': 'job_1234',
+                'name': 'process'
+            }],
+            'id': '0123-oozie-oozi-C',
+            'appName': 'o2-workflow',
+            'status': 'RUNNING'
+        })
+        self.assertEqual(result['aggregate_status'], '%s_%s_%s' % \
+        (ApplicationState.STARTED, 'RUNNING', ERROR_STATUS['ERROR']))
+
+        #Oozie Workflow in case of Suspended and job in OK state
+        oozie_worfklow_patch.return_value = {
+            'job-1': {
+                'status': 'OK',
+                'yarnId': 'application_1234',
+                'name': 'process'
+            }
+            }
+        process_component_data_patch.return_value = 'OK'
+        result = application_summary.oozie_workflow_handler({
+            'actions': [{
+                'externalId': 'job_1234',
+                'name': 'process'
+            }],
+            'id': '0123-oozie-oozi-C',
+            'appName': 'o2-workflow',
+            'status': 'SUSPENDED'
+        })
+        self.assertEqual(result['aggregate_status'], '%s_%s_%s' % \
+        (ApplicationState.COMPLETED, 'SUSPENDED', FAILURE_STATUS['OK']))
+
+        #Oozie Workflow in case of Killed and job in OK state
+        oozie_worfklow_patch.return_value = {
+            'job-1': {
+                'status': 'OK',
+                'yarnId': 'application_1234',
+                'name': 'process'
+            }
+            }
+        process_component_data_patch.return_value = 'OK'
+        result = application_summary.oozie_workflow_handler({
+            'actions': [{
+                'externalId': 'job_1234',
+                'name': 'process'
+            }],
+            'id': '0123-oozie-oozi-C',
+            'appName': 'o2-workflow',
+            'status': 'KILLED'
+        })
+        self.assertEqual(result['aggregate_status'], '%s_%s_%s' % \
+        (ApplicationState.COMPLETED, 'KILLED', FAILURE_STATUS['OK']))
+
+    @patch('requests.get')
+    def test_oozie_api_request(self, mock_req):
+        """
+        Check Oozie API request returns a dict object
+        """
+        mock_req.return_value = type('obj', (object,), {'status_code' : 200, 'text': json.dumps({
+            'id': '01234-oozie-oozi-w',
+            'appName': 'o2-workflow',
+            'status': 'PREP'
+        })})
+        result = application_summary.oozie_api_request('01234-oozie-oozi-w')
+        self.assertIsInstance(result, dict)
+
+    @patch('application_summary.oozie_api_request')
+    @patch('application_summary.yarn_info')
+    @patch('application_summary.spark_job_handler')
+    def test_get_oozie_workflow_actions(self, spark_job_patch, yarn_job_patch, oozie_api_patch):
+        """
+        Testing Oozie component's action handling for both Coordinator and Workflow
+        """
+        #In case of Oozie workflow with a Mapreduce job whose Yarn status's Failed
+        yarn_job_patch.return_value = {'yarnStatus': 'FAILED', \
+        'yarnFinalStatus': 'FAILED', 'type': 'MAPREDUCE'}
+        result = application_summary.get_oozie_workflow_actions([
+            {
+                'status': 'RUNNING',
+                'externalId': 'job_1235',
+                'name': 'download',
+                'type': 'shell',
+                'externalChildIDs': None
+            }])
+        self.assertEqual(result, {
+            'job-1': {
+                'status': 'ERROR',
+                'information': None,
+                'applicationType': 'MAPREDUCE',
+                'name': 'download',
+                'yarnId': 'application_1235'
+            }})
+
+        #In case of Oozie workflow with a Spark job whose Yarn status's Running
+        yarn_job_patch.return_value = {'yarnStatus': 'RUNNING', \
+        'yarnFinalStatus': 'UNDEFINED', 'type': 'MAPREDUCE'}
+        yarn_job_patch.return_value = {'yarnStatus': 'RUNNING', \
+        'yarnFinalStatus': 'UNDEFINED', 'type': 'SPARK'}
+        spark_job_patch.return_value = {'state': 'OK', 'information': {
+            "stageSummary": {
+                "active": 0,
+                "number_of_stages": 448,
+                "complete": 448,
+                "pending": 0,
+                "failed": 0
+            },
+            "jobSummary": {
+                "unknown": 0,
+                "number_of_jobs": 112,
+                "running": 0,
+                "succeeded": 112,
+                "failed": 0
+            }}}
+        result = application_summary.get_oozie_workflow_actions([
+            {
+                'status': 'RUNNING',
+                'externalId': 'job_1235',
+                'name': 'process',
+                'type': 'spark',
+                'externalChildIDs': 'job_1236'
+            }])
+        self.assertEqual(result, {
+            'job-1': {
+                'status': 'OK',
+                'information': {
+                    "stageSummary": {
+                        "active": 0,
+                        "number_of_stages": 448,
+                        "complete": 448,
+                        "pending": 0,
+                        "failed": 0
+                    },
+                    "jobSummary": {
+                        "unknown": 0,
+                        "number_of_jobs": 112,
+                        "running": 0,
+                        "succeeded": 112,
+                        "failed": 0
+                    }},
+                'applicationType': 'SPARK',
+                'name': 'process',
+                'yarnId': 'application_1236'
+            }})
+
+        #In case of Oozie Coordinator with a worklfow have one subworkflow which have one Mapreduce job
+        yarn_job_patch.return_value = {'yarnStatus': 'RUNNING', \
+        'yarnFinalStatus': 'UNDEFINED', 'type': 'MAPREDUCE'}
+        oozie_api_patch.side_effect = [{
+            'status': 'SUCCEEDED',
+            'appName': 'o1-workflow',
+            'actions': [{
+                'status': 'OK',
+                'externalId': '0124-oozie-oozi-W',
+                'name': 'download',
+                'type': 'sub-workflow'
+                }],
+            'id': '0123-oozie-oozi-W',
+        }, {
+            'status': 'SUCCEEDED',
+            'appName': 'o1-subworkflow',
+            'actions': [
+                {
+                    'status': 'OK',
+                    'externalId': 'job_123',
+                    'name': 'download',
+                    'type': 'shell',
+                    'externalChildIDs': None
+                }
+            ], 'id': '0124-oozie-oozi-W'}]
+        result = application_summary.get_oozie_workflow_actions([
+            {
+                'status': 'SUCCEEDED',
+                'externalId': '0123-oozie-oozi-W',
+                'type': None
+            }])
+        self.assertEqual(result, {
+            "workflow-1": {
+                "status": "OK",
+                "oozieId": "0123-oozie-oozi-W",
+                "actions": {
+                    "subworkflow-1": {
+                        "status": "OK",
+                        "oozieId": "0124-oozie-oozi-W",
+                        "actions": {
+                            "job-1": {
+                                "status": "OK",
+                                "information": None,
+                                "applicationType": "MAPREDUCE",
+                                "name": "download",
+                                "yarnId": "application_123"
+                            }
+                        },
+                        "name": "o1-subworkflow"
+                    }
+                    },
+                "name": "o1-workflow"
+            }})
+
+    @patch('requests.get')
+    def test_spark_job_handler(self, spark_mock_req):
+        """
+        Testing Spark API for jobs and stage information
+        """
+        spark_mock_req.side_effect = [type('obj', (object,), {'status_code' : 200, 'text': json.dumps([
+            {
+                'status': 'RUNNING',
+                'stageIds': [
+                    5,
+                    6
+                ],
+                'jobId': 1
+            },
+            {
+                'status': 'SUCCEEDED',
+                'stageIds': [
+                    0,
+                    1
+                ],
+                'jobId': 0
+            }])}), type('obj', (object,), {'status_code' : 200, 'text': json.dumps([
+                {
+                    'status': 'COMPLETE',
+                    'stageId': 23
+                },
+                {
+                    'status': 'COMPLETE',
+                    'stageId': 22
+                }])})]
+        result = application_summary.spark_job_handler('application_123')
+        self.assertEqual(result, {
+            'information': {
+                'stageSummary': {
+                    'active': 0,
+                    'number_of_stages': 2,
+                    'complete': 2,
+                    'pending': 0,
+                    'failed': 0
+                },
+                'jobSummary': {
+                    'unknown': 0,
+                    'number_of_jobs': 2,
+                    'running': 1,
+                    'succeeded': 1,
+                    'failed': 0
+                }
+            },
+            'state': 'OK'
+            })
+
+    @patch('requests.get')
+    def test_yarn_info(self, yarn_mock_req):
+        """
+        Tetsing Yarn API provides application data by providing it's application id
+        """
+        yarn_mock_req.side_effect = [type('obj', (object,), {'status_code' : 200, 'text': json.dumps({
+            'app': {
+                'state': 'KILLED',
+                'name': 'app1-example-job',
+                'applicationType': 'SPARK',
+                'startedTime': 1513311261486,
+                'finalStatus': 'KILLED'
+            }})}), type('obj', (object,), {'status_code' : 200, 'text': json.dumps({
+                'RemoteException': {
+                    'message': 'java.lang.Exception: app with id: application_123 not found'}})})]
+
+        result = application_summary.yarn_info('application_123')
+        self.assertEqual(result, {
+            'yarnStatus': 'KILLED',
+            'yarnFinalStatus': 'KILLED',
+            'type': 'SPARK',
+            'startedTime': 1513311261486
+        })
+
+        result = application_summary.yarn_info('application_123')
+        self.assertEqual(result, {
+            'yarnStatus': 'NOT FOUND',
+            'yarnFinalStatus': 'UNKNOWN',
+            'type': 'UNKNOWN',
+            'information': 'app with id application_123 not found'
+        })

--- a/api/src/main/resources/test_application_summary_registrar.py
+++ b/api/src/main/resources/test_application_summary_registrar.py
@@ -1,0 +1,52 @@
+import json
+import unittest
+from mock import Mock, patch
+from application_summary_registrar import HBaseAppplicationSummary
+
+class AppplicationSummaryRegistrarTests(unittest.TestCase):
+    @patch('happybase.Connection.table.scan', return_value=['app1', 'app2', 'app3'])
+    @patch('happybase.Connection')
+    def test_remove_app_entry(self, hbase_mock, dm_app_list):
+        """
+        Testing deleted aplication get removed from Hbase
+        """
+        registrar = HBaseAppplicationSummary('1.2.3.4')
+        application_list = ['app1', 'app2']
+        registrar.remove_app_entry(application_list)
+        for application, _ in dm_app_list:
+            if application not in application_list:
+                hbase_mock.return_value.table.return_value.delete.assert_called_once_with(application)
+
+    @patch('happybase.Connection')
+    def test_post_to_hbase(self, hbase_mock):
+        """
+        Testing Summary data ets posted to Hbase
+        """
+        registrar = HBaseAppplicationSummary('1.2.3.4')
+        registrar.post_to_hbase({'aname': {'aggregate_status': 'status', 'component-1': 'data'}})
+        hbase_mock.return_value.table.return_value.put.assert_called_once_with('aname', \
+        {'cf:component_data': json.dumps({'component-1': 'data'}), 'cf:aggregate_status': 'status'})
+
+    @patch('happybase.Connection')
+    def test_get_summary_data(self, hbase_mock):
+        """
+        Test get summary data
+        """
+        #In case of application have data in platform_application_summary and platform_applications
+        registrar = HBaseAppplicationSummary('1.2.3.4')
+        registrar.get_dm_data = Mock(return_value={'cf:create_data': '{"create": "data"}', })
+        hbase_mock.return_value.table.return_value.row.return_value = {'cf:component_data': \
+        json.dumps({"component-1": "data"}), 'cf:aggregate_status': 'status'}
+        result = registrar.get_summary_data('name')
+        self.assertEqual(result, {'name': {'aggregate_status': 'status', 'component-1': 'data'}})
+
+        #In case of application have data only in platform_applications not in platform_application_summary
+        registrar.get_dm_data = Mock(return_value={'cf:create_data': '{"create": "data"}', })
+        hbase_mock.return_value.table.return_value.row.return_value = {}
+        result = registrar.get_summary_data('name')
+        self.assertEqual(result, {'name': {'status': 'Not Available'}})
+
+        #In case of application have data not in platform_applications itself
+        registrar.get_dm_data = Mock(return_value={})
+        result = registrar.get_summary_data('name')
+        self.assertEqual(result, {'name': {'status': 'Not Created'}})

--- a/api/src/main/resources/test_deployer_manager.py
+++ b/api/src/main/resources/test_deployer_manager.py
@@ -85,6 +85,7 @@ class DeploymentManagerTest(unittest.TestCase):
             lambda app, status, info=None: set_dictionary_value(application_data, app,
                                                                 {"status": status, "information": info})
         self.mock_application_registar = mock_application_registar
+        self.mock_summary_registar = Mock()
 
         self.test_package_name = "aPakageForTesting-1.0.0"
         self.test_app_name = "anAppForTesting"
@@ -266,6 +267,7 @@ class DeploymentManagerTest(unittest.TestCase):
             repository=self.mock_repository,
             package_registrar=self.mock_package_registar,
             application_registrar=self.mock_application_registar,
+            application_summary_registrar=self.mock_summary_registar,
             environment=self.mock_environment,
             config=self.mock_config)
 
@@ -584,12 +586,14 @@ class DeploymentManagerTest(unittest.TestCase):
         repository = Mock()
         package_registrar = Mock()
         application_registrar = Mock()
+        application_summary_registrar = Mock()
         environment = {"namespace": "some_namespace", 'webhdfs_host': 'webhdfshost', 'webhdfs_port': 'webhdfsport'}
         config = {"deployer_thread_limit": 10}
 
         dmgr = DeploymentManager(repository,
                                  package_registrar,
                                  application_registrar,
+                                 application_summary_registrar,
                                  environment,
                                  config)
 
@@ -602,12 +606,14 @@ class DeploymentManagerTest(unittest.TestCase):
         package_registrar = Mock()
         package_registrar.list_packages.return_value = expected_packages
         application_registrar = Mock()
+        application_summary_registrar = Mock()
         environment = {"namespace": "some_namespace", 'webhdfs_host': 'webhdfshost', 'webhdfs_port': 'webhdfsport'}
         config = {"deployer_thread_limit": 10}
 
         dmgr = DeploymentManager(repository,
                                  package_registrar,
                                  application_registrar,
+                                 application_summary_registrar,
                                  environment,
                                  config)
 
@@ -633,12 +639,14 @@ class DeploymentManagerTest(unittest.TestCase):
 
         package_registrar = Mock()
         application_registrar = Mock()
+        application_summary_registrar = Mock()
         environment = {"namespace": "some_namespace", 'webhdfs_host': 'webhdfshost', 'webhdfs_port': 'webhdfsport'}
         config = {"deployer_thread_limit": 10}
 
         dmgr = DeploymentManager(repository,
                                  package_registrar,
                                  application_registrar,
+                                 application_summary_registrar,
                                  environment,
                                  config)
 
@@ -650,12 +658,14 @@ class DeploymentManagerTest(unittest.TestCase):
         package_registrar.get_package_deploy_status.return_value = None
         package_registrar.package_exists.return_value = False
         application_registrar = Mock()
+        application_summary_registrar = Mock()
         environment = {"namespace": "some_namespace", 'webhdfs_host': 'webhdfshost', 'webhdfs_port': 'webhdfsport'}
         config = {"deployer_thread_limit": 10}
 
         dmgr = DeploymentManager(repository,
                                  package_registrar,
                                  application_registrar,
+                                 application_summary_registrar,
                                  environment,
                                  config)
 
@@ -673,12 +683,14 @@ class DeploymentManagerTest(unittest.TestCase):
         package_registrar = Mock()
         application_registrar = Mock()
         application_registrar.list_applications_for_package.return_value = expected_applications
+        application_summary_registrar = Mock()
         environment = {"namespace": "some_namespace", 'webhdfs_host': 'webhdfshost', 'webhdfs_port': 'webhdfsport'}
         config = {"deployer_thread_limit": 10}
 
         dmgr = DeploymentManager(repository,
                                  package_registrar,
                                  application_registrar,
+                                 application_summary_registrar,
                                  environment,
                                  config)
 
@@ -691,12 +703,14 @@ class DeploymentManagerTest(unittest.TestCase):
         package_registrar = Mock()
         application_registrar = Mock()
         application_registrar.list_applications.return_value = expected_applications
+        application_summary_registrar = Mock()
         environment = {"namespace": "some_namespace", 'webhdfs_host': 'webhdfshost', 'webhdfs_port': 'webhdfsport'}
         config = {"deployer_thread_limit": 10}
 
         dmgr = DeploymentManager(repository,
                                  package_registrar,
                                  application_registrar,
+                                 application_summary_registrar,
                                  environment,
                                  config)
 
@@ -713,12 +727,14 @@ class DeploymentManagerTest(unittest.TestCase):
             'package_name': 'package_name',
             'status': ApplicationState.STARTING,
             'information': None}
+        application_summary_registrar = Mock()
         environment = {"namespace": "some_namespace", 'webhdfs_host': 'webhdfshost', 'webhdfs_port': 'webhdfsport'}
         config = {"deployer_thread_limit": 10}
 
         dmgr = DeploymentManager(repository,
                                  package_registrar,
                                  application_registrar,
+                                 application_summary_registrar,
                                  environment,
                                  config)
 
@@ -728,6 +744,7 @@ class DeploymentManagerTest(unittest.TestCase):
         repository = Mock()
         package_registrar = Mock()
         application_registrar = Mock()
+        application_summary_registrar = Mock()
         environment = {"namespace": "some_namespace", 'webhdfs_host': 'webhdfshost', 'webhdfs_port': 'webhdfsport'}
         config = {"deployer_thread_limit": 10}
 
@@ -738,6 +755,7 @@ class DeploymentManagerTest(unittest.TestCase):
         dmgr = DeploymentManagerTester(repository,
                                        package_registrar,
                                        application_registrar,
+                                       application_summary_registrar,
                                        environment,
                                        config)
         dmgr.set_package_progress("name", PackageDeploymentState.DEPLOYING)
@@ -750,11 +768,13 @@ class DeploymentManagerTest(unittest.TestCase):
         package_registrar.get_package_deploy_status.return_value = None
         package_registrar.package_exists.return_value = False
         application_registrar = Mock()
+        application_summary_registrar = Mock()
         environment = {"namespace": "some_namespace", 'webhdfs_host': 'webhdfshost', 'webhdfs_port': 'webhdfsport'}
         config = {"deployer_thread_limit": 10}
         dmgr = DeploymentManager(repository,
                                  package_registrar,
                                  application_registrar,
+                                 application_summary_registrar,
                                  environment,
                                  config)
 
@@ -775,12 +795,14 @@ class DeploymentManagerTest(unittest.TestCase):
             'package_name': 'package_name',
             'status': ApplicationState.STARTED,
             'information': None}
+        application_summary_registrar = Mock()
         environment = {"namespace": "some_namespace", 'webhdfs_host': 'webhdfshost', 'webhdfs_port': 'webhdfsport'}
         config = {"deployer_thread_limit": 10}
 
         dmgr = DeploymentManager(repository,
                                  package_registrar,
                                  application_registrar,
+                                 application_summary_registrar,
                                  environment,
                                  config)
 
@@ -801,13 +823,36 @@ class DeploymentManagerTest(unittest.TestCase):
             'package_name': 'package_name',
             'status': ApplicationState.NOTCREATED,
             'information': None}
+        application_summary_registrar = Mock()
         environment = {"namespace": "some_namespace", 'webhdfs_host': 'webhdfshost', 'webhdfs_port': 'webhdfsport'}
         config = {"deployer_thread_limit": 10}
 
         dmgr = DeploymentManager(repository,
                                  package_registrar,
                                  application_registrar,
+                                 application_summary_registrar,
                                  environment,
                                  config)
 
         self.assertRaises(NotFound, dmgr.get_application_detail, 'name')
+
+    def test_get_application_summary(self):
+        repository = Mock()
+        package_registrar = Mock()
+        application_registrar = Mock()
+        application_summary_registrar = Mock()
+        application_summary_registrar.get_summary_data.return_value = {'name':{
+            'aggregate_status': 'COMPLETED_WITH_NO_FAILURES',
+            'component-1': {}
+        }}
+        environment = {"namespace": "some_namespace", 'webhdfs_host': 'webhdfshost', 'webhdfs_port': 'webhdfsport'}
+        config = {"deployer_thread_limit": 10}
+
+        dmgr = DeploymentManager(repository,
+                                 package_registrar,
+                                 application_registrar,
+                                 application_summary_registrar,
+                                 environment,
+                                 config)
+
+        self.assertEqual(dmgr.get_application_summary('name'), {'name':{'aggregate_status': 'COMPLETED_WITH_NO_FAILURES', 'component-1': {}}})


### PR DESCRIPTION
## Problem Statement:
PNDA-2834: Currently deployment manager providing the status based on start / stop button action in UI and it is not providing the actual status where the application was executed.

## Analysis:
- Platform-deployment-manager has three component handler
	- OOZIE
	- SPARK-STREAMING
	- JUPYTER
- Jobs will be submitted to YARN for execution
- OOZIE, YARN and SPARK-STREAMING can provide status for applications
- Need to create a python job that will query OOZIE, YARN and SPARK,
  for application's actual status

## Approach:
- Get list of application from existing “platform_applications” HBase table
- For each application get create data and calculate the total number of component present in all the applications
- Components of applications will be processed in multiprocessing environment for that process count will be calculated based on the formula below
````
                     total component count *  max  time for processing  single  component  (max 6 seconds)
Process  Count = ----------------------------------------------------------------------------------------------
                                       total time-bound( Currently 60 seconds )
````
- If calculated process count exceeds 4, set process count to 4
- Components will be processed based on its type OOZIE and SPARK STREAMING
- After components processed build aggregate status based on component's status for all application
- Once aggregate status built for all application, post it to HBase 
- Above steps will be executed in an infinite loop with an interval of 60 seconds

## Changes:
- platform-deployment-manager
  - Created a python job that will have the described approach  
  - Created a python file that will post summary data to HBase and get summary data from HBase
  - Added a new API /summary to provide summary status built for every application that will be fetched from HBase
  
  Files added:
  - platform-deployment-manager/api/src/main/resources/application_summary.py
  - platform-deployment-manager/api/src/main/resources/application_summary_registrar.py
  - platform-deployment-manager/api/src/main/resources/test_application_summary.py
  - platform-deployment-manager/api/src/main/resources/test_application_summary_registrar.py
  
  Files modified:
  - platform-deployment-manager/api/src/main/resources/app.py
  - platform-deployment-manager/api/src/main/resources/deployment-manager.py
  - platform-deployment-manager/api/src/main/resources/lifecycle-states.py
  - platform-deployment-manager/api/src/main/resources/test_deployer_manager.py
  
- platform-salt
  - Created a daemon for python job created in platform-deployment-manager
  
  Files added:
  - platform-salt/salt/deployment-manager/templates/dm-application-summary.conf.tpl
  - platform-salt/salt/deployment-manager/templates/dm-application-summary.service.tpl
  
  Files modified:
  - platform-salt/salt/deployment-manager/init.sls
  
- platform-console-backend
  - Added /summary API to get summary status from deployment manager
  
  Files modified:
  - platform-console-backend/console-backend-data-manager/routes/applications.js

## Test details:
Verified the Changes in
- UBUNTU-PICO - CDH & HDP
- UBUNTU-STD - CDH & HDP
- RHEL-PICO - CDH & HDP
- RHEL-STD - CDH & HDP
