### PR TITLE
Support for spark2 streaming applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 .settings/
 .coverage
 pnda-build/
+.virtualenv

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ HTTP and Python bindings are provided for these APIs.
 
 ## Connecting
 
-By default, the Deployment Manager is installed on `edge` node o. In order to access it go to: http://[cluster-name]-cdh-edge:5000
+By default, the Deployment Manager is installed on the `edge` node. To access the API use: http://[cluster-name]-cdh-edge:5000
 
 ## Repository ##
 
@@ -523,6 +523,17 @@ environment_yarn_resource_manager_mr_port 8032
 environment_yarn_resource_manager_port  8088
 environment_zookeeper_port              2181
 environment_zookeeper_quorum            cluster-cdh-mgr1
+````
+
+## Spark Streamining Specific Variables ##
+The following varibles are only injected for Spark streaming components. They may be overridden in properties.json, for example to override `component_spark_version`, include `spark_version` in properties.json.
+
+````
+component_spark_version            major version of spark to use. Only applicable to HDP clusters, when using CDH PNDA does not support side-by-side Spark frameworks and whatever version is run by the spark-submit command will be used.
+component_spark_submit_args        additional arguments to spark-submit
+(java only) component_main_jar     the jar containing the job code
+(python only) component_main_py    the python file containing the job code
+(python only) component_py_files   additional python files to pass to spark-submit
 ````
 
 ## Oozie Specific Variables ##

--- a/api/src/main/resources/plugins/sparkStreaming.py
+++ b/api/src/main/resources/plugins/sparkStreaming.py
@@ -77,6 +77,8 @@ class SparkStreamingCreator(Creator):
         root_user = self._environment['cluster_root_user']
         target_host = 'localhost'
 
+        if 'component_spark_version' not in properties:
+            properties['component_spark_version'] = '1'
         if 'component_spark_submit_args' not in properties:
             properties['component_spark_submit_args'] = ''
         if 'component_py_files' not in properties:

--- a/api/src/main/resources/plugins/systemd.service.py.tpl
+++ b/api/src/main/resources/plugins/systemd.service.py.tpl
@@ -7,6 +7,7 @@ User=${application_user}
 WorkingDirectory=/opt/${environment_namespace}/${component_application}/${component_name}/
 ExecStartPre=/opt/${environment_namespace}/${component_application}/${component_name}/yarn-kill.py
 ExecStopPost=/opt/${environment_namespace}/${component_application}/${component_name}/yarn-kill.py
+Environment=SPARK_MAJOR_VERSION=${component_spark_version}
 ExecStart=/usr/bin/spark-submit --driver-java-options "-Dlog4j.configuration=file:////opt/${environment_namespace}/${component_application}/${component_name}/log4j.properties" --conf 'spark.executor.extraJavaOptions=-Dlog4j.configuration=file:////opt/${environment_namespace}/${component_application}/${component_name}/log4j.properties' --name '${component_job_name}' --master yarn-cluster --py-files application.properties,${component_py_files} ${component_spark_submit_args} ${component_main_py}
 Restart=always
 RestartSec=2

--- a/api/src/main/resources/plugins/systemd.service.tpl
+++ b/api/src/main/resources/plugins/systemd.service.tpl
@@ -7,6 +7,7 @@ User=${application_user}
 WorkingDirectory=/opt/${environment_namespace}/${component_application}/${component_name}/
 ExecStartPre=/opt/${environment_namespace}/${component_application}/${component_name}/yarn-kill.py
 ExecStopPost=/opt/${environment_namespace}/${component_application}/${component_name}/yarn-kill.py
+Environment=SPARK_MAJOR_VERSION=${component_spark_version}
 ExecStart=/usr/bin/spark-submit --driver-java-options "-Dlog4j.configuration=file:////opt/${environment_namespace}/${component_application}/${component_name}/log4j.properties" --class ${component_main_class} --name '${component_job_name}' --master yarn-cluster --files log4j.properties ${component_spark_submit_args} ${component_main_jar}
 Restart=always
 RestartSec=2

--- a/api/src/main/resources/plugins/upstart.conf.py.tpl
+++ b/api/src/main/resources/plugins/upstart.conf.py.tpl
@@ -2,7 +2,9 @@ start on runlevel [2345]
 stop on runlevel [016]
 respawn
 respawn limit unlimited
+setuid ${application_user}
+env SPARK_MAJOR_VERSION=${component_spark_version}
 pre-start exec /opt/${environment_namespace}/${component_application}/${component_name}/yarn-kill.py
 pre-stop exec /opt/${environment_namespace}/${component_application}/${component_name}/yarn-kill.py
 chdir /opt/${environment_namespace}/${component_application}/${component_name}/
-exec sudo -u ${application_user} spark-submit --driver-java-options "-Dlog4j.configuration=file:///opt/${environment_namespace}/${component_application}/${component_name}/log4j.properties" --conf 'spark.executor.extraJavaOptions=-Dlog4j.configuration=file:///opt/${environment_namespace}/${component_application}/${component_name}/log4j.properties' --name '${component_job_name}' --master yarn-cluster --py-files application.properties,${component_py_files} ${component_spark_submit_args} ${component_main_py}
+exec spark-submit --driver-java-options "-Dlog4j.configuration=file:///opt/${environment_namespace}/${component_application}/${component_name}/log4j.properties" --conf 'spark.executor.extraJavaOptions=-Dlog4j.configuration=file:///opt/${environment_namespace}/${component_application}/${component_name}/log4j.properties' --name '${component_job_name}' --master yarn-cluster --py-files application.properties,${component_py_files} ${component_spark_submit_args} ${component_main_py}

--- a/api/src/main/resources/plugins/upstart.conf.tpl
+++ b/api/src/main/resources/plugins/upstart.conf.tpl
@@ -2,8 +2,10 @@ start on runlevel [2345]
 stop on runlevel [016]
 respawn
 respawn limit unlimited
+setuid ${application_user}
+env SPARK_MAJOR_VERSION=${component_spark_version}
 pre-start exec /opt/${environment_namespace}/${component_application}/${component_name}/yarn-kill.py
 pre-stop exec /opt/${environment_namespace}/${component_application}/${component_name}/yarn-kill.py
 env programDir=/opt/${environment_namespace}/${component_application}/${component_name}/
 chdir /opt/${environment_namespace}/${component_application}/${component_name}/
-exec sudo -u ${application_user} spark-submit --driver-java-options "-Dlog4j.configuration=file:///${programDir}log4j.properties" --class ${component_main_class} --name '${component_job_name}' --master yarn-cluster --files log4j.properties ${component_spark_submit_args} ${component_main_jar}
+exec spark-submit --driver-java-options "-Dlog4j.configuration=file:///${programDir}log4j.properties" --class ${component_main_class} --name '${component_job_name}' --master yarn-cluster --files log4j.properties ${component_spark_submit_args} ${component_main_jar}


### PR DESCRIPTION
Allow `spark_version` to be set in an application component's
`properties.json` that causes the SPARK_MAJOR_VERSION environment
variable to be set accordingly. Defaults to '1' if not set by the user,
for backward compatibility.

PNDA-3654