### PR TITLE
PNDA-4234: Hive query uri added as part of environment in HDP

### DIFF
--- a/api/src/main/resources/deployer_utils.py
+++ b/api/src/main/resources/deployer_utils.py
@@ -181,6 +181,7 @@ def fill_hadoop_env_hdp(env):
             elif role_name == "HIVE_SERVER":
                 env['hive_server'] = '%s' % component_host(component_detail)
                 env['hive_port'] = '10000'
+                env['cm_status_links']['HQUERY'] = 'http://%s:8080/#/main/view/HIVE/auto_hive_instance' % (hadoop_manager_ip)
 
 def fill_hadoop_env_cdh(env):
     # pylint: disable=E1103


### PR DESCRIPTION
### PNDA-4234: Hive query cog sends you to about: blank

## Analysis:
- In console, HiveQuery cog expects HQUERY metric
- HQUERY metric should contain URL for Ambari HiveQuery page

## Change:
- HQUERY metric added as part of env cm_status_links