### PR TITLE
PNDA-4517: Oozie ssh action support for flink batch jobs

### DIFF
--- a/api/src/main/resources/plugins/flink-oozie.execute.py.sh.tpl
+++ b/api/src/main/resources/plugins/flink-oozie.execute.py.sh.tpl
@@ -1,0 +1,1 @@
+sudo -u ${application_user} ${environment_flink} run -m yarn-cluster ${component_flink_config_args} -ynm ${component_job_name} -v ${flink_python_jar} ${component_staged_path}/${component_main_py} ${component_application_args}

--- a/api/src/main/resources/plugins/flink-oozie.execute.sh.tpl
+++ b/api/src/main/resources/plugins/flink-oozie.execute.sh.tpl
@@ -1,0 +1,1 @@
+sudo -u ${application_user} ${environment_flink} run -m yarn-cluster ${component_flink_config_args} -ynm ${component_job_name} --class ${component_main_class} ${component_staged_path}/${component_main_jar}  ${component_application_args}


### PR DESCRIPTION
### Problem Statement:
Oozie does not natively support an action for submitting Flink job on yarn-cluster.  Need to use SSH action for executing the flink batch job in PNDA

### Changes Done:
- OOZIE SSH action will ssh into specified machine execute a shell script specified in the workflow. 
- So in oozie.py wrote a function to stage the code locally and generate a shell script which will have the flink executable command to execute the job

### Test Details:
AWS-RHEL-HDP-PICO-STD
OpenStack-RHEL-HDP-PICO

Dependancy PR: 
**PNDA-4500** (Used flink-stop.py from PNDA-4500)
https://github.com/pndaproject/platform-deployment-manager/pull/78