### PR TITLE
PNDA-4546: Authorization through user parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Applications may be paused and restarted. This leaves all the installed componen
 
 Each Creator implements a specific set of steps to uninstall components of its associated type. The Creator is passed the application data associated with the package and component and uses this to execute those steps.
 
+### User authentication ###
+
+User who creates application can do operations on the specific application by mentioning username as a URI parameter. If unauthorised user tries to do any opertaion on application 403 Forbidden will be thrown.
+An admin user will be available, admin user can do any operation on any application. Admin user can be configured using pillar data
 
 # Requirements
 
@@ -83,8 +87,8 @@ To build the Deployment Manager, change to the `api` directory, which contains t
   * [GET /packages/_package_/applications](#list-applications-that-have-been-created-from-package)
   * [GET /applications/_application_/status](#get-the-status-for-application)
   * [GET /applications/_application_/summary](#get-the-summary-status-for-application)
-  * [POST /applications/_application_/start](#start-application)
-  * [POST /applications/_application_/stop](#stop-application)
+  * [POST /applications/_application_](#start-application)
+  * [POST /applications/_application_](#stop-application)
   * [GET /applications/_application_](#get-full-information-for-application)
   * [PUT /applications/_application_](#create-application-from-package)
   * [DELETE /applications/_application_](#destroy-application)
@@ -358,23 +362,27 @@ Response Codes:
 
 ### Start _application_
 ````
-POST /applications/<application>/start
+POST /applications/<application>/start?user=<username>
 
 Response Codes:
 202 - Accepted, poll /applications/<application>/status for status
+403 - Unauthorised user
 404 - Application not known
 500 - Server Error
 ````
+Username, who created the application should be passed. See [User Authentication](#user-authentication) section for more details
 
 ### Stop _application_
 ````
-POST /applications/<application>/stop
+POST /applications/<application>/stop?user=<username>
 
 Response Codes:
 202 - Accepted, poll /applications/<application>/status for status
+403 - Unauthorised user
 404 - Application not known
 500 - Server Error
 ````
+Username, who created the application should be passed. See [User Authentication](#user-authentication) section for more details
 
 ### Get full information for _application_
 ````
@@ -419,9 +427,8 @@ Example response:
 ### Create _application_ from _package_
 
 ````
-PUT /applications/<application>
+PUT /applications/<application>?user=<username>
 {
-	"user": "<username>",
 	"package": "<package>",
 	"<componentType>": {
 		"<componentName>": {
@@ -439,7 +446,6 @@ Response Codes:
 
 Example body:
 {
-	"user": "somebody",
 	"package": "<package>",
 	"oozie": {
 		"example": {
@@ -448,18 +454,21 @@ Example body:
 	}
 }
 
-Package and user are mandatory, property settings are optional
+Package is mandatory, property settings are optional
 ````
+Username, who creates this application should be passed. See [User Authentication](#user-authentication) section for more details
 
 ### Destroy _application_
 ````
-DELETE /applications/<application>
+DELETE /applications/<application>?user=<username>
 
 Response Codes:
 200 - OK
+403 - Unauthorised user
 404 - Application not known
 500 - Server Error
 ````
+Username, who created the application should be passed. See [User Authentication](#user-authentication) section for more details
 
 ## Environment Endpoints API
 ### List environment variables known to the deployment manager
@@ -549,3 +558,4 @@ oozie.libpath                  /pnda/deployment/platform
 oozie.use.system.libpath       true
 user.name                      prod1
 ````
+

--- a/api/src/main/resources/deployment_manager.py
+++ b/api/src/main/resources/deployment_manager.py
@@ -30,7 +30,7 @@ import traceback
 import requests
 
 import application_creator
-from exceptiondef import ConflictingState, NotFound
+from exceptiondef import ConflictingState, NotFound, Forbidden
 from package_parser import PackageParser
 from async_dispatcher import AsyncDispatcher
 from lifecycle_states import ApplicationState, PackageDeploymentState
@@ -268,7 +268,7 @@ class DeploymentManager(object):
         applications = self._application_registrar.list_applications()
         return applications
 
-    def _assert_application_status(self, application, required_status):
+    def _assert_application_status(self, application, required_status, user_name):
         app_info = self.get_application_info(application)
         status = app_info['status']
 
@@ -279,15 +279,22 @@ class DeploymentManager(object):
             else:
                 raise ConflictingState(json.dumps({'status': status}))
 
+        if status != ApplicationState.NOTCREATED:
+            created_user = app_info['overrides']['user']  
+            if user_name != created_user and user_name != self._config["admin_user"]:
+                logging.info("User not authorized: %s", user_name)
+                raise Forbidden(json.dumps({'user': user_name}))
+
+
     def _assert_application_exists(self, application):
         status = self.get_application_info(application)['status']
         if status == ApplicationState.NOTCREATED:
             raise NotFound(json.dumps({'status': status}))
 
-    def start_application(self, application):
+    def start_application(self, application, user_name):
         logging.info('start_application')
         with self._lock:
-            self._assert_application_status(application, ApplicationState.CREATED)
+            self._assert_application_status(application, ApplicationState.CREATED, user_name)
             self._mark_starting(application)
 
         def do_work():
@@ -306,10 +313,10 @@ class DeploymentManager(object):
 
         self.dispatcher.run_as_asynch(task=do_work)
 
-    def stop_application(self, application):
+    def stop_application(self, application, user_name):
         logging.info('stop_application')
         with self._lock:
-            self._assert_application_status(application, ApplicationState.STARTED)
+            self._assert_application_status(application, ApplicationState.STARTED, user_name)
             self._mark_stopping(application)
 
         def do_work():
@@ -360,7 +367,7 @@ class DeploymentManager(object):
         package_data_path = None
 
         with self._lock:
-            self._assert_application_status(application, ApplicationState.NOTCREATED)
+            self._assert_application_status(application, ApplicationState.NOTCREATED, overrides['user'])
             self._assert_package_status(package, PackageDeploymentState.DEPLOYED)
             defaults = self.get_package_info(package)['defaults']
             package_data_path = self._package_registrar.get_package_data(package)
@@ -404,10 +411,10 @@ class DeploymentManager(object):
         # set the status:
         self._application_registrar.set_application_status(application, app_status, error_message)
 
-    def delete_application(self, application):
+    def delete_application(self, application, user_name):
         logging.info('delete_application')
         with self._lock:
-            self._assert_application_status(application, [ApplicationState.CREATED, ApplicationState.STARTED])
+            self._assert_application_status(application, [ApplicationState.CREATED, ApplicationState.STARTED], user_name)
             self._mark_destroying(application)
 
         def do_work():

--- a/api/src/main/resources/exceptiondef.py
+++ b/api/src/main/resources/exceptiondef.py
@@ -38,6 +38,12 @@ class NotFound(DmException):
         super(NotFound, self).__init__(arg)
         self.msg = arg
 
+class Forbidden(DmException):
+
+    def __init__(self, arg):
+        super(Forbidden, self).__init__(arg)
+        self.msg = arg
+
 
 class ConflictingState(DmException):
 


### PR DESCRIPTION
### Problem Statement:
With the current implementation of deployment-manager, user1 can able to do operations on user2's application.

### Changes Done:
- **?user=<user_name>** query added in create/start/stop/delete API's of application. If a non-owner user tried to initiate any operation, will get 403 Forbidden
- Added an admin user in the config, the admin user can able to do the operation on any application
- Undeploy package can only do by the admin user

