### PR TITLE
Add component properties to control restart of systemd jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,8 @@ The following varibles are only injected for Spark streaming components. They ma
 ````
 component_spark_version            major version of spark to use. Only applicable to HDP clusters, when using CDH PNDA does not support side-by-side Spark frameworks and whatever version is run by the spark-submit command will be used.
 component_spark_submit_args        additional arguments to spark-submit
+component_respawn_type             whether to restart the process when it exits. Valid values are 'always' and 'no'.
+component_respawn_timeout_sec      used with component_respawn_type to set how long to wait (in seconds) before restarting the process when it exits.
 (java only) component_main_jar     the jar containing the job code
 (python only) component_main_py    the python file containing the job code
 (python only) component_py_files   additional python files to pass to spark-submit

--- a/api/src/main/resources/plugins/flink.systemd.service.py.tpl
+++ b/api/src/main/resources/plugins/flink.systemd.service.py.tpl
@@ -9,5 +9,5 @@ ExecStartPre=/opt/${environment_namespace}/${component_application}/${component_
 ExecStopPost=/opt/${environment_namespace}/${component_application}/${component_name}/yarn-kill.py
 Environment=FLINK_VERSION=${component_flink_version}
 ExecStart=/usr/bin/flink run -m  yarn-cluster ${component_flink_config_args} -ynm ${component_job_name} -v ${flink_python_jar} ${component_main_py} ${component_application_args}
-${respawn}
-${respawn_limit}
+Restart=${component_respawn_type}
+RestartSec=${component_respawn_timeout_sec}

--- a/api/src/main/resources/plugins/flink.systemd.service.tpl
+++ b/api/src/main/resources/plugins/flink.systemd.service.tpl
@@ -9,5 +9,5 @@ ExecStartPre=/opt/${environment_namespace}/${component_application}/${component_
 ExecStopPost=/opt/${environment_namespace}/${component_application}/${component_name}/yarn-kill.py
 Environment=FLINK_VERSION=${component_flink_version}
 ExecStart=/usr/bin/flink run -m  yarn-cluster ${component_flink_config_args} -ynm ${component_job_name} --class ${component_main_class} ${component_main_jar} ${component_application_args}
-${respawn}
-${respawn_limit}
+Restart=${component_respawn_type}
+RestartSec=${component_respawn_timeout_sec}

--- a/api/src/main/resources/plugins/sparkStreaming.py
+++ b/api/src/main/resources/plugins/sparkStreaming.py
@@ -89,6 +89,10 @@ class SparkStreamingCreator(Common):
             copy(os.path.join(this_dir, 'yarn-kill.py'), staged_component_path)
             service_script = 'systemd.service.tpl' if java_app else 'systemd.service.py.tpl'
             service_script_install_path = '/usr/lib/systemd/system/%s.service' % service_name
+            if 'component_respawn_type' not in properties:
+                properties['component_respawn_type'] = 'always'
+            if 'component_respawn_timeout_sec' not in properties:
+                properties['component_respawn_timeout_sec'] = '2'
             copy(os.path.join(this_dir, service_script), staged_component_path)
 
         self._fill_properties(os.path.join(staged_component_path, service_script), properties)

--- a/api/src/main/resources/plugins/systemd.service.py.tpl
+++ b/api/src/main/resources/plugins/systemd.service.py.tpl
@@ -9,5 +9,5 @@ ExecStartPre=/opt/${environment_namespace}/${component_application}/${component_
 ExecStopPost=/opt/${environment_namespace}/${component_application}/${component_name}/yarn-kill.py
 Environment=SPARK_MAJOR_VERSION=${component_spark_version}
 ExecStart=${environment_spark_submit} --driver-java-options "-Dlog4j.configuration=file:////opt/${environment_namespace}/${component_application}/${component_name}/log4j.properties" --conf 'spark.executor.extraJavaOptions=-Dlog4j.configuration=file:////opt/${environment_namespace}/${component_application}/${component_name}/log4j.properties' --name '${component_job_name}' --master yarn-cluster --py-files application.properties,${component_py_files} ${component_spark_submit_args} ${component_main_py}
-Restart=always
-RestartSec=2
+Restart=${component_respawn_type}
+RestartSec=${component_respawn_timeout_sec}

--- a/api/src/main/resources/plugins/systemd.service.tpl
+++ b/api/src/main/resources/plugins/systemd.service.tpl
@@ -9,5 +9,5 @@ ExecStartPre=/opt/${environment_namespace}/${component_application}/${component_
 ExecStopPost=/opt/${environment_namespace}/${component_application}/${component_name}/yarn-kill.py
 Environment=SPARK_MAJOR_VERSION=${component_spark_version}
 ExecStart=${environment_spark_submit} --driver-java-options "-Dlog4j.configuration=file:////opt/${environment_namespace}/${component_application}/${component_name}/log4j.properties" --class ${component_main_class} --name '${component_job_name}' --master yarn-cluster --files log4j.properties ${component_spark_submit_args} ${component_main_jar}
-Restart=always
-RestartSec=2
+Restart=${component_respawn_type}
+RestartSec=${component_respawn_timeout_sec}


### PR DESCRIPTION
Add component_respawn_type and component_respawn_timeout_sec properties to control whether sparkStreaming or Flink component will be restarted when it exits. If it is restarted component_respawn_timeout_sec sets how long to wait before doing so.

PNDA-4540