### PR TITLE
Rename user parameter for deployment manager API

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Response Codes:
 
 ### Start _application_
 ````
-POST /applications/<application>/start?user=<username>
+POST /applications/<application>/start?user.name=<username>
 
 Response Codes:
 202 - Accepted, poll /applications/<application>/status for status
@@ -371,7 +371,7 @@ user - User with permisson to perform this action on the application should be p
 
 ### Stop _application_
 ````
-POST /applications/<application>/stop?user=<username>
+POST /applications/<application>/stop?user.name=<username>
 
 Response Codes:
 202 - Accepted, poll /applications/<application>/status for status
@@ -426,7 +426,7 @@ Example response:
 ### Create _application_ from _package_
 
 ````
-PUT /applications/<application>?user=<username>
+PUT /applications/<application>?user.name=<username>
 {
 	"package": "<package>",
 	"<componentType>": {
@@ -461,7 +461,7 @@ Package is mandatory, property settings are optional
 
 ### Destroy _application_
 ````
-DELETE /applications/<application>?user=<username>
+DELETE /applications/<application>?user.name=<username>
 
 Response Codes:
 200 - OK

--- a/api/src/main/resources/app.py
+++ b/api/src/main/resources/app.py
@@ -224,7 +224,7 @@ class ApplicationsHandler(BaseHandler):
 class ApplicationDetailHandler(BaseHandler):
     @asynchronous
     def post(self, name, action):
-        user_name = self.get_argument("user")
+        user_name = self.get_argument("user.name")
         def do_call():
             if action == 'start':
                 dm.start_application(name, user_name)
@@ -270,9 +270,9 @@ class ApplicationHandler(BaseHandler):
             return
 
         if 'user' in request_body:
-            self.send_client_error("Invalid request body. User should be passed in URI")
+            self.send_client_error("Invalid request body. User should be passed as URI parameter user.name")
             return
-        user_name = self.get_argument("user")
+        user_name = self.get_argument("user.name")
         def do_call():
             request_body.update({'user': user_name})
             dm.create_application(request_body['package'], aname, request_body)
@@ -289,7 +289,7 @@ class ApplicationHandler(BaseHandler):
 
     @asynchronous
     def delete(self, name):
-        user_name = self.get_argument("user")
+        user_name = self.get_argument("user.name")
         def do_call():
             dm.delete_application(name, user_name)
             self.send_accepted()


### PR DESCRIPTION
Rename user parameter for deployment manager API from user to user.name to match the default knox behaviour.

PNDA-4613