### PR TITLE
PNDA-4543: Handling wrong oozie spark version request

### DIFF
--- a/api/src/main/resources/application_creator.py
+++ b/api/src/main/resources/application_creator.py
@@ -46,6 +46,11 @@ class ApplicationCreator(object):
                                  environment['webhdfs_port'],
                                  'hdfs')
 
+    def assert_application_properties(self, override_properties, default_properties):
+        for component_type, component_properties in default_properties.iteritems():
+            creator = self._load_creator(component_type)
+            creator.assert_application_properties(override_properties.get(component_type, {}), component_properties)
+
     def create_application(self, package_data_path, package_metadata, application_name, property_overrides):
 
         logging.debug("create_application: %s", application_name)

--- a/api/src/main/resources/deployment_manager.py
+++ b/api/src/main/resources/deployment_manager.py
@@ -464,6 +464,7 @@ class DeploymentManager(object):
             self._authorize(user_name, Resources.PACKAGE, package_owner, Actions.READ)
             self._authorize(user_name, Resources.APPLICATION, None, Actions.CREATE)
             defaults = self.get_package_info(package)['defaults']
+            self._application_creator.assert_application_properties(overrides, defaults)
             package_data_path = self._package_registrar.get_package_data(package)
             self._application_registrar.create_application(package, application, overrides, defaults)
             self._mark_creating(application)

--- a/api/src/main/resources/plugins/base_creator.py
+++ b/api/src/main/resources/plugins/base_creator.py
@@ -106,6 +106,15 @@ class Creator(object):
         '''
         pass
 
+    def assert_application_properties(self, override_properties, default_properties):
+        '''
+        Assert application properties before creating the application
+
+        override_properties - properties overrided by user
+        default_properties - default properties present in package
+        '''
+        pass
+
     def destroy_component(self, application_name, create_data):
         '''
         Destroys component of the package of given component type

--- a/api/src/main/resources/plugins/flink.py
+++ b/api/src/main/resources/plugins/flink.py
@@ -87,7 +87,7 @@ class FlinkCreator(Common):
                 properties['component_respawn_type'] = 'no'
             else:
                 properties['component_respawn_type'] = 'always'
-        
+
         if 'component_respawn_timeout_sec' not in properties:
             if properties['component_flink_job_type'] == 'batch':
                 properties['component_respawn_timeout_sec'] = '0'

--- a/api/src/main/resources/test_application_creator.py
+++ b/api/src/main/resources/test_application_creator.py
@@ -31,7 +31,7 @@ from exceptiondef import FailedValidation, FailedCreation
 class ApplicationCreatorTests(unittest.TestCase):
 
     user = getpass.getuser()
-    config = {'stage_root': 'stage', 'plugins_path': 'plugins'}
+    config = {'stage_root': 'stage', 'plugins_path': 'plugins', 'oozie_spark_version': '1'}
     environment = {
         'webhdfs_host': 'webhdfshost',
         'webhdfs_port': 'webhdfsport',
@@ -239,10 +239,27 @@ class ApplicationCreatorTests(unittest.TestCase):
             def json(self):
                 return {'id': 'someid'}
 
+        default_properties = {
+            "oozie": {
+                "componentA": {
+                    "spark_version": "1"
+                }
+            }
+        }
+        override_properties = {
+            "user": "root",
+            "oozie": {
+                "componentA": {
+                    "spark_version": "2"
+                }
+            }
+        }
+
         post_mock.return_value = Resp()
         cmd_mock.return_value = (0, 'dev')
         with patch("__builtin__.open", mock_open(read_data="[]")):
             creator = ApplicationCreator(self.config, self.environment, self.service)
+            self.assertRaises(FailedValidation, creator.assert_application_properties, override_properties, default_properties)
             self.assertRaises(FailedCreation, creator.create_application, 'abcd', self.package_metadata_2, 'aname', self.property_overrides)
 
     @patch('starbase.Connection')

--- a/api/src/main/resources/test_deployer_manager.py
+++ b/api/src/main/resources/test_deployer_manager.py
@@ -75,7 +75,7 @@ class DeploymentManagerTest(unittest.TestCase):
             'queue_policy': 'echo dev',
             'namespace': 'mockspace'
         }
-        self.mock_config = {"deployer_thread_limit": 1, 'stage_root': 'stage', 'plugins_path': 'plugins'}
+        self.mock_config = {"deployer_thread_limit": 1, 'stage_root': 'stage', 'plugins_path': 'plugins', 'oozie_spark_version': '1'}
         # mock app registrar:
         mock_application_registar = Mock()
         application_data = {}
@@ -934,4 +934,3 @@ class DeploymentManagerTest(unittest.TestCase):
             deployment_manager.start_application(self.test_app_name, 'username2')
 
         self.assertRaises(Forbidden, expect_exception)
-        


### PR DESCRIPTION
**Problem Statement:**
Deployment Manager accepts Spark Oozie jobs for the wrong version of Spark.

**Changes Done:**

1. Add assert application properties as one of the pre-check before making an entry in Hbase for creating the application.
2. Add a new type of exception to handle incorrect application properties Precondition Failure-412
3. If any incorrect application property is given, CREATE API will result in 412 with the Precondition Failure exception.
4. Below condition will be added as part of this bug in assert application properties: 
      A. It will not allow to create the application, If deployed oozie spark version does not match with the requested spark_version for the application.
5. If properties.json does not contain spark_version, configured oozie with spark version will be used (deployed oozie spark version).

**Test Details:**
PICO_HDP_RHEL with oozie version 1 & 2.