### PR TITLE
Exceptions do not have message attribute in Python 3

### DIFF
--- a/api/src/main/resources/deployer_system_test.py
+++ b/api/src/main/resources/deployer_system_test.py
@@ -358,7 +358,7 @@ class DeployerRestClientTester(object):
             # should never reach this statement:
             assert False
         except AssertionError as ex:
-            assert "404" in ex.message
+            assert "404" in ex.msg
 
     def test_undeploy(self, test_package):
         logging.debug("Undeploying test package...")


### PR DESCRIPTION
Use 'msg' instead of 'message' which is deprecated