### PR TITLE
[FIX] Force HTTPS requests to Maven Repository

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -47,4 +47,29 @@ either express or implied.
         </plugin>
      </plugins>
   </build>
+  <pluginRepositories>
+    <pluginRepository>
+       <id>central</id>
+       <name>Central Repository</name>
+       <url>https://repo.maven.apache.org/maven2</url>
+       <layout>default</layout>
+       <snapshots>
+         <enabled>false</enabled>
+       </snapshots>
+       <releases>
+         <updatePolicy>never</updatePolicy>
+       </releases>
+     </pluginRepository>
+  </pluginRepositories>
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
The Maven repository now is full migrated to HTTPS, and the requests on HTTP fail